### PR TITLE
charts: remove dependencies on bitnami charts

### DIFF
--- a/charts/apps/matrix/Chart.yaml
+++ b/charts/apps/matrix/Chart.yaml
@@ -1,15 +1,11 @@
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update matrixdotorg/synapse Docker tag to v1.136.0
+      description: Remove built-in bitnami/postgres chart
 apiVersion: v2
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.136.0
-dependencies:
-  - name: postgresql
-    version: "16.x"
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: postgresql.enabled
+dependencies: []
 description: A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 home: "https://github.com/zekker6/helm-charts/tree/main/charts/apps/matrix"
 icon: https://upload.wikimedia.org/wikipedia/commons/7/7c/Matrix_icon.svg
@@ -21,4 +17,4 @@ name: matrix
 sources:
   - "https://github.com/zekker6/helm-charts/tree/main/charts/apps/matrix"
 type: application
-version: 2.82.0
+version: 3.0.0

--- a/charts/apps/matrix/README.md
+++ b/charts/apps/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 2.82.0](https://img.shields.io/badge/Version-2.82.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.136.0](https://img.shields.io/badge/AppVersion-v1.136.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.136.0](https://img.shields.io/badge/AppVersion-v1.136.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -14,12 +14,21 @@ Chart source: https://github.com/typokign/matrix-chart
 - (Optional) Latest version of Riot Web
 - (Optional) Choice of lightweight Exim relay or external mail server for email notifications
 - (Optional) Coturn TURN server for VoIP calls
-- (Optional) PostgreSQL cluster via stable/postgresql chart
 - (Optional) [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) IRC bridge
 - (Optional) [tulir/mautrix-whatsapp](https://github.com/tulir/mautrix-whatsapp) WhatsApp bridge
 - (Optional) [Half-Shot/matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) Discord bridge
 - Fully configurable via values.yaml
 - Ingress definition for federated Synapse and Riot
+
+# Breaking changes
+
+## 2.82.0 -> 3.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -31,7 +40,6 @@ Chart source: https://github.com/typokign/matrix-chart
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
 
 ## TL;DR
 
@@ -255,12 +263,11 @@ N/A
 | nameOverride | string | `""` |  |
 | networkPolicies.enabled | bool | `false` |  |
 | postgresql.database | string | `"matrix"` |  |
-| postgresql.enabled | bool | `true` |  |
 | postgresql.hostname | string | `""` |  |
 | postgresql.password | string | `"matrix"` |  |
-| postgresql.persistence.size | string | `"8Gi"` |  |
 | postgresql.port | int | `5432` |  |
-| postgresql.primary.initdb.scriptsConfigMap | string | `"{{ .Release.Name }}-postgresql-initdb"` |  |
+| postgresql.ssl | bool | `false` |  |
+| postgresql.sslMode | string | `""` |  |
 | postgresql.username | string | `"matrix"` |  |
 | riot.branding.authFooterLinks | list | `[]` |  |
 | riot.branding.authHeaderLogoUrl | string | `""` |  |

--- a/charts/apps/matrix/README_CONFIG.md.gotmpl
+++ b/charts/apps/matrix/README_CONFIG.md.gotmpl
@@ -7,12 +7,21 @@ Chart source: https://github.com/typokign/matrix-chart
 - (Optional) Latest version of Riot Web
 - (Optional) Choice of lightweight Exim relay or external mail server for email notifications
 - (Optional) Coturn TURN server for VoIP calls
-- (Optional) PostgreSQL cluster via stable/postgresql chart
 - (Optional) [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) IRC bridge
 - (Optional) [tulir/mautrix-whatsapp](https://github.com/tulir/mautrix-whatsapp) WhatsApp bridge
 - (Optional) [Half-Shot/matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) Discord bridge
 - Fully configurable via values.yaml
 - Ingress definition for federated Synapse and Riot
+
+# Breaking changes
+
+## 2.82.0 -> 3.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 {{- end -}}
 

--- a/charts/apps/matrix/templates/_helpers.tpl
+++ b/charts/apps/matrix/templates/_helpers.tpl
@@ -106,9 +106,5 @@ Synapse hostname prepended with https:// to form a complete URL
 Helper function to get a postgres connection string for the database, with all of the auth and SSL settings automatically applied
 */}}
 {{- define "matrix.postgresUri" -}}
-{{- if .Values.postgresql.enabled -}}
-postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ include "matrix.fullname" . }}-postgresql/%s{{ if .Values.postgresql.ssl }}?ssl=true&sslmode={{ .Values.postgresql.sslMode}}{{ end }}
-{{- else -}}
 postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ .Values.postgresql.hostname }}:{{ .Values.postgresql.port }}/%s{{ if .Values.postgresql.ssl }}?ssl=true&sslmode={{ .Values.postgresql.sslMode }}{{ end }}
-{{- end }}
 {{- end }}

--- a/charts/apps/matrix/values.yaml
+++ b/charts/apps/matrix/values.yaml
@@ -297,9 +297,6 @@ ingress:
 
 # PostgreSQL Database Configuration
 postgresql:
-  # Whether to deploy the stable/postgresql chart with this chart. If disabled, make sure PostgreSQL is available at the hostname below and credentials are configured below
-  enabled: true
-
   username: matrix
   password: matrix
   database: matrix
@@ -308,15 +305,8 @@ postgresql:
   hostname: ""
   port: 5432
 
-  # Storage to allocate for stable/postgresql
-  persistence:
-    size: 8Gi
-
-  primary:
-    initdb:
-      # If postgresql.enabled, stable/postgresql will run the scripts in templates/postgresql/initdb-configmap.yaml
-      # If using an external Postgres server, make sure to configure the database as specified at https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
-      scriptsConfigMap: "{{ .Release.Name }}-postgresql-initdb"
+  ssl: false
+  sslMode: ""
 
 # Synapse Kubernetes resource settings
 synapse:

--- a/charts/apps/paperless/Chart.yaml
+++ b/charts/apps/paperless/Chart.yaml
@@ -1,7 +1,9 @@
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update ghcr.io/paperless-ngx/paperless-ngx Docker tag to v2.18.2
+      description: Remove built-in bitnami/postgres chart
+    - kind: changed
+      description: Remove built-in bitnami/redis chart
 apiVersion: v2
 # renovate: image=ghcr.io/paperless-ngx/paperless-ngx
 appVersion: 2.18.2
@@ -9,14 +11,6 @@ dependencies:
   - name: common
     repository: https://zekker6.github.io/helm-charts
     version: 0.5.2
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: "16.x"
-  - condition: redis.enabled
-    name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 21.2.x
 description: Paperless - Index and archive all of your scanned paper documents
 home: https://github.com/zekker6/helm-charts/tree/main/charts/apps/paperless
 icon: https://raw.githubusercontent.com/the-paperless-project/paperless/master/src/paperless/static/paperless/img/logo-dark.png
@@ -31,4 +25,4 @@ name: paperless
 sources:
   - https://github.com/paperless-ngx/paperless-ngx
   - https://github.com/zekker6/helm-charts/tree/main/charts/apps/paperless
-version: 9.94.0
+version: 10.0.0

--- a/charts/apps/paperless/README.md
+++ b/charts/apps/paperless/README.md
@@ -1,12 +1,22 @@
 # paperless
 
-![Version: 9.94.0](https://img.shields.io/badge/Version-9.94.0-informational?style=flat-square) ![AppVersion: 2.18.2](https://img.shields.io/badge/AppVersion-2.18.2-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: 2.18.2](https://img.shields.io/badge/AppVersion-2.18.2-informational?style=flat-square)
 
 Paperless - Index and archive all of your scanned paper documents
 
 **This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/zekker6/helm-charts/issues/new)**
 
 Chart taken from k8s-at-home repo [here](https://github.com/k8s-at-home/charts/tree/master/charts/stable/paperless).
+
+# Breaking changes
+
+## 9.94.0 -> 10.0.0
+
+The chart no longer includes postgresql and redis charts by default.
+Previously, it was using a bitnami/postgresql and bitnami/redis which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -21,8 +31,6 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
-| https://charts.bitnami.com/bitnami | redis | 21.2.x |
 | https://zekker6.github.io/helm-charts | common | 0.5.2 |
 
 ## TL;DR

--- a/charts/apps/paperless/README_CONFIG.md.gotmpl
+++ b/charts/apps/paperless/README_CONFIG.md.gotmpl
@@ -1,5 +1,16 @@
 {{- define "custom.custom.notes" -}}
 Chart taken from k8s-at-home repo [here](https://github.com/k8s-at-home/charts/tree/master/charts/stable/paperless).
+
+# Breaking changes
+
+## 9.94.0 -> 10.0.0
+
+The chart no longer includes postgresql and redis charts by default.
+Previously, it was using a bitnami/postgresql and bitnami/redis which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
+
 {{- end -}}
 
 {{- define "custom.custom.configuration.header" -}}

--- a/charts/apps/plausible-analytics/Chart.yaml
+++ b/charts/apps/plausible-analytics/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update Helm release clickhouse to 4.0.1
+      description: Remove built-in bitnami/postgres chart
 apiVersion: v2
 # renovate: image=ghcr.io/plausible/community-edition
 appVersion: v3.0.1
@@ -10,10 +10,6 @@ dependencies:
     name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
     version: 4.0.1
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: "16.x"
 description: A Helm Chart for Plausible Analytics - a simple and privacy-friendly alternative to Google Analytics
 home: https://plausible.io/
 icon: https://plausible.io/docs/img/favicon.png
@@ -30,4 +26,4 @@ sources:
   - https://hub.docker.com/r/plausible/analytics
   - https://github.com/plausible/analytics
 type: application
-version: 0.13.1
+version: 1.0.0

--- a/charts/apps/plausible-analytics/README.md
+++ b/charts/apps/plausible-analytics/README.md
@@ -1,6 +1,6 @@
 # plausible-analytics
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm Chart for Plausible Analytics - a simple and privacy-friendly alternative to Google Analytics
 
@@ -10,6 +10,14 @@ Chart was originally created and maintained by [Varac](https://varac.net) [here]
 
 This chart uses v2.1.0 version of Plausible Analytics.
 See release notes to learn more about upgrade steps: https://github.com/plausible/analytics/releases/tag/v2.1.0
+
+## 0.13.1 -> 1.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -23,7 +31,6 @@ See release notes to learn more about upgrade steps: https://github.com/plausibl
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
 | https://sentry-kubernetes.github.io/charts | clickhouse | 4.0.1 |
 
 ## TL;DR
@@ -116,8 +123,7 @@ N/A
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| postgresql | object | `{"auth":{"database":"plausible","postgresPassword":"b8f1ad468e00b344b2c6bf495c4ffc28"},"enabled":true}` | Postgres Database |
-| postgresql.auth | object | `{"database":"plausible","postgresPassword":"b8f1ad468e00b344b2c6bf495c4ffc28"}` | Sub-chart values, see https://artifacthub.io/packages/helm/bitnami/postgresql The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING |
+| postgresql | object | `{"url":"postgress://postgres:84a075c6b5e74bd2e8f0f9bf98d669f0@plausible-postgresql:5432/plausible"}` | Postgres Database |
 | postmark | object | `{"apiKey":null}` | Alternatively, you can use Postmark to send transactional emails |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/apps/plausible-analytics/README_CONFIG.md.gotmpl
+++ b/charts/apps/plausible-analytics/README_CONFIG.md.gotmpl
@@ -3,6 +3,15 @@ Chart was originally created and maintained by [Varac](https://varac.net) [here]
 
 This chart uses v2.1.0 version of Plausible Analytics.
 See release notes to learn more about upgrade steps: https://github.com/plausible/analytics/releases/tag/v2.1.0
+
+## 0.13.1 -> 1.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
+
 {{- end -}}
 
 {{- define "custom.custom.notes" -}}

--- a/charts/apps/plausible-analytics/templates/secret.yaml
+++ b/charts/apps/plausible-analytics/templates/secret.yaml
@@ -8,12 +8,8 @@ metadata:
   {{- include "plausible-analytics.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if (or .Values.postgresql.enabled .Values.postgresql.url) }}
-  {{- if .Values.postgresql.url}}
+  {{- if .Values.postgresql.url }}
   DATABASE_URL: {{ .Values.postgresql.url | toString | b64enc }}
-  {{- else }}
-  DATABASE_URL: {{ (printf "postgresql://%s:%s@%s-postgresql/%s" (.Values.postgresql.username | default "postgres") .Values.postgresql.auth.postgresPassword (include "plausible-analytics.fullname" .) (.Values.postgresql.auth.database | default "plausible")) | b64enc }}
-  {{- end }}
   {{- end }}
   {{- if (or .Values.clickhouse.enabled .Values.clickhouse.url) }}
   {{- if .Values.clickhouse.url }}

--- a/charts/apps/plausible-analytics/values.yaml
+++ b/charts/apps/plausible-analytics/values.yaml
@@ -19,16 +19,8 @@ externalSecret:
 
 # -- Postgres Database
 postgresql:
-  enabled: true
   # Replace the default values with your own
-  # url: "postgress://postgres:b8f1ad468e00b344b2c6bf495c4ffc28@plausible-postgresql:5432/plausible"
-
-  # -- Sub-chart values, see https://artifacthub.io/packages/helm/bitnami/postgresql
-  # The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-  auth:
-    # Change this for real use. Password is left in chart to be used in CI
-    postgresPassword: "b8f1ad468e00b344b2c6bf495c4ffc28"
-    database: "plausible"
+  url: "postgress://postgres:84a075c6b5e74bd2e8f0f9bf98d669f0@plausible-postgresql:5432/plausible"
 
 # -- Clickhouse Database
 clickhouse:

--- a/docs/charts/matrix.md
+++ b/docs/charts/matrix.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 2.82.0](https://img.shields.io/badge/Version-2.82.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.136.0](https://img.shields.io/badge/AppVersion-v1.136.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.136.0](https://img.shields.io/badge/AppVersion-v1.136.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -14,12 +14,21 @@ Chart source: https://github.com/typokign/matrix-chart
 - (Optional) Latest version of Riot Web
 - (Optional) Choice of lightweight Exim relay or external mail server for email notifications
 - (Optional) Coturn TURN server for VoIP calls
-- (Optional) PostgreSQL cluster via stable/postgresql chart
 - (Optional) [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) IRC bridge
 - (Optional) [tulir/mautrix-whatsapp](https://github.com/tulir/mautrix-whatsapp) WhatsApp bridge
 - (Optional) [Half-Shot/matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) Discord bridge
 - Fully configurable via values.yaml
 - Ingress definition for federated Synapse and Riot
+
+# Breaking changes
+
+## 2.82.0 -> 3.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -31,7 +40,6 @@ Chart source: https://github.com/typokign/matrix-chart
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
 
 ## TL;DR
 
@@ -255,12 +263,11 @@ N/A
 | nameOverride | string | `""` |  |
 | networkPolicies.enabled | bool | `false` |  |
 | postgresql.database | string | `"matrix"` |  |
-| postgresql.enabled | bool | `true` |  |
 | postgresql.hostname | string | `""` |  |
 | postgresql.password | string | `"matrix"` |  |
-| postgresql.persistence.size | string | `"8Gi"` |  |
 | postgresql.port | int | `5432` |  |
-| postgresql.primary.initdb.scriptsConfigMap | string | `"{{ .Release.Name }}-postgresql-initdb"` |  |
+| postgresql.ssl | bool | `false` |  |
+| postgresql.sslMode | string | `""` |  |
 | postgresql.username | string | `"matrix"` |  |
 | riot.branding.authFooterLinks | list | `[]` |  |
 | riot.branding.authHeaderLogoUrl | string | `""` |  |

--- a/docs/charts/paperless.md
+++ b/docs/charts/paperless.md
@@ -1,12 +1,22 @@
 # paperless
 
-![Version: 9.94.0](https://img.shields.io/badge/Version-9.94.0-informational?style=flat-square) ![AppVersion: 2.18.2](https://img.shields.io/badge/AppVersion-2.18.2-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: 2.18.2](https://img.shields.io/badge/AppVersion-2.18.2-informational?style=flat-square)
 
 Paperless - Index and archive all of your scanned paper documents
 
 **This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/zekker6/helm-charts/issues/new)**
 
 Chart taken from k8s-at-home repo [here](https://github.com/k8s-at-home/charts/tree/master/charts/stable/paperless).
+
+# Breaking changes
+
+## 9.94.0 -> 10.0.0
+
+The chart no longer includes postgresql and redis charts by default.
+Previously, it was using a bitnami/postgresql and bitnami/redis which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -21,8 +31,6 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
-| https://charts.bitnami.com/bitnami | redis | 21.2.x |
 | https://zekker6.github.io/helm-charts | common | 0.5.2 |
 
 ## TL;DR

--- a/docs/charts/plausible-analytics.md
+++ b/docs/charts/plausible-analytics.md
@@ -1,6 +1,6 @@
 # plausible-analytics
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm Chart for Plausible Analytics - a simple and privacy-friendly alternative to Google Analytics
 
@@ -10,6 +10,14 @@ Chart was originally created and maintained by [Varac](https://varac.net) [here]
 
 This chart uses v2.1.0 version of Plausible Analytics.
 See release notes to learn more about upgrade steps: https://github.com/plausible/analytics/releases/tag/v2.1.0
+
+## 0.13.1 -> 1.0.0
+
+The chart no longer includes postgresql chart by default.
+Previously, it was using a bitnami/postgresql which became obsolete after introducing a paid subscription for bitnami docker images.
+See these issues for more details:
+- https://github.com/bitnami/charts/issues/35164
+- https://github.com/zekker6/helm-charts/issues/825
 
 ## Source Code
 
@@ -23,7 +31,6 @@ See release notes to learn more about upgrade steps: https://github.com/plausibl
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.x |
 | https://sentry-kubernetes.github.io/charts | clickhouse | 4.0.1 |
 
 ## TL;DR
@@ -116,8 +123,7 @@ N/A
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| postgresql | object | `{"auth":{"database":"plausible","postgresPassword":"b8f1ad468e00b344b2c6bf495c4ffc28"},"enabled":true}` | Postgres Database |
-| postgresql.auth | object | `{"database":"plausible","postgresPassword":"b8f1ad468e00b344b2c6bf495c4ffc28"}` | Sub-chart values, see https://artifacthub.io/packages/helm/bitnami/postgresql The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING |
+| postgresql | object | `{"url":"postgress://postgres:84a075c6b5e74bd2e8f0f9bf98d669f0@plausible-postgresql:5432/plausible"}` | Postgres Database |
 | postmark | object | `{"apiKey":null}` | Alternatively, you can use Postmark to send transactional emails |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |


### PR DESCRIPTION
This commit removes dependencies to bitnami/postgresql and bitnami/redis charts. This is caused by bitnami removing free docker images support effective from 28 August 2025, so those charts are no longer free. See: https://github.com/bitnami/charts/issues/35164

Currently, there are a few alternatives present but there is no chart which is generally preferred by the community. Due to this, instead of providing a chart out of the box charts now require "bringing you own DB" in a way user prefers.

Related: https://github.com/zekker6/helm-charts/issues/825
